### PR TITLE
Fix pointer type on QueryAttributesFile

### DIFF
--- a/Reloaded.Universal.Redirector/FileAccessServer.cs
+++ b/Reloaded.Universal.Redirector/FileAccessServer.cs
@@ -18,7 +18,7 @@ public unsafe class FileAccessServer
     private static IHook<Native.NtCreateFile> _ntCreateFileHook = null!;
     private static IHook<Native.NtQueryAttributesFile> _ntQueryAttributesFileHook = null!;
     private const string _prefix = "\\??\\";
-    
+
     [ThreadStatic]
     private static bool _inQueryAttributesFile;
 
@@ -42,14 +42,14 @@ public unsafe class FileAccessServer
 
         if (ntQueryAttributesFilePointer != IntPtr.Zero)
             _ntQueryAttributesFileHook = hooks.CreateHook<Native.NtQueryAttributesFile>(
-                (delegate* unmanaged[Stdcall]<Native.OBJECT_ATTRIBUTES*, uint, int>) &NtQueryAttributesFileHookFn,
+                (delegate* unmanaged[Stdcall]<Native.OBJECT_ATTRIBUTES*, IntPtr, int>) &NtQueryAttributesFileHookFn,
                 (long) ntQueryAttributesFilePointer).Activate();
     }
 
     /* Hooks */
 
     [UnmanagedCallersOnly(CallConvs = new[] { typeof(CallConvStdcall) })]
-    private static int NtQueryAttributesFileHookFn(Native.OBJECT_ATTRIBUTES* objectAttributes, uint fileAttributes)
+    private static int NtQueryAttributesFileHookFn(Native.OBJECT_ATTRIBUTES* objectAttributes, IntPtr fileAttributes)
     {
         if (_inQueryAttributesFile)
             return _ntQueryAttributesFileHook.OriginalFunction.Value.Invoke(objectAttributes, fileAttributes);

--- a/Reloaded.Universal.Redirector/Native.cs
+++ b/Reloaded.Universal.Redirector/Native.cs
@@ -20,10 +20,10 @@ internal class Native
         public FuncPtr
         <
             BlittablePointer<IntPtr>,               // handle
-            FileAccess,                             // access 
+            FileAccess,                             // access
             BlittablePointer<OBJECT_ATTRIBUTES>,    // objectAttributes
             BlittablePointer<IO_STATUS_BLOCK>,      // ioStatus
-            BlittablePointer<long>,                 // allocSize 
+            BlittablePointer<long>,                 // allocSize
             uint,                                   // fileAttributes
             FileShare,                              // share
             uint,                                   // createDisposition
@@ -31,9 +31,9 @@ internal class Native
             IntPtr,                                 // eaBuffer
             uint,                                   // eaLength
             int                                     // Return Value
-        >Value;    
+        >Value;
     }
-    
+
     /// <summary>
     /// Retrieves basic attributes for the specified file object.
     /// (The description here is a partial, lazy copy from MSDN)
@@ -45,9 +45,9 @@ internal class Native
         public FuncPtr
         <
             BlittablePointer<OBJECT_ATTRIBUTES>,    // objectAttributes
-            uint,                                   // fileAttributes
+            IntPtr,                                 // fileAttributes
             int                                     // Return Value
-        >Value;    
+        >Value;
     }
 
     /// <summary>
@@ -104,7 +104,7 @@ internal class Native
         /// </summary>
         public IntPtr SecurityQualityOfService;
     }
-    
+
     /// <summary>
     /// Represents a singular unicode string.
     /// </summary>


### PR DESCRIPTION
When attempting to use the redirector with [Rabbit and Steel](https://store.steampowered.com/app/2132850/Rabbit_and_Steel/), my game would crash on startup as well as Reloaded internals itself failing. I tracked this down to a bug in the NtQueryAttributesFile hook. MSDN defines [NtQueryAttributesFile](https://learn.microsoft.com/en-us/windows/win32/devnotes/ntqueryattributesfile) as FileInformation to be PFILE_BASIC_INFORMATION (a pointer to FILE_BASIC_INFORMATION), but it was defined as a uint in the PR that added it, which is not pointer-sized on x64. I don't know if this works with x86, as I don't have a game to test it with, but I would presume IntPtr will resolve to size 4 on x86.